### PR TITLE
¡Cambios!

### DIFF
--- a/plugin/src/main/java/io/github/wickeddroid/plugin/command/staff/CommandTime.java
+++ b/plugin/src/main/java/io/github/wickeddroid/plugin/command/staff/CommandTime.java
@@ -42,14 +42,6 @@ public class CommandTime implements CommandClass {
           final @Sender Player sender,
           final int time
   ) {
-    this.uhcGame.setCurrentTime(time);
-    if(time > uhcGame.getTimeForPvp() ) {
-      uhcGame.setUhcGameState(UhcGameState.PVP);
-    }
-
-    if(time > uhcGame.getTimeForMeetup()) {
-      uhcGame.setUhcGameState(UhcGameState.MEETUP);
-    }
-
+    this.uhcGame.setStartTime(uhcGame.getStartTime() - (time * 1000L));
   }
 }

--- a/plugin/src/main/java/io/github/wickeddroid/plugin/game/Game.java
+++ b/plugin/src/main/java/io/github/wickeddroid/plugin/game/Game.java
@@ -13,6 +13,7 @@ public class Game {
     private boolean spectatorsEnabled = false;
     private boolean initialBoat = true;
     private boolean replaceGhastDrop = false;
+    private boolean useExperimentalScatter = false;
 
     public boolean starterInvulnerability() { return this.starterInvulnerability; }
     public int invulnerabilityDuration() { return this.invulnerabilityDuration; }
@@ -20,8 +21,8 @@ public class Game {
     public boolean papermanEnabled() { return this.papermanEnabled; }
     public boolean spectatorsEnabled() { return this.spectatorsEnabled; }
     public boolean initialBoat() { return this.initialBoat; }
-
     public boolean replaceGhastDrop() { return this.replaceGhastDrop; }
+    public boolean useExperimentalScatter() { return this.useExperimentalScatter; }
 
     private PlayerList playerList = new PlayerList();
 

--- a/plugin/src/main/java/io/github/wickeddroid/plugin/game/Game.java
+++ b/plugin/src/main/java/io/github/wickeddroid/plugin/game/Game.java
@@ -12,6 +12,7 @@ public class Game {
     private boolean papermanEnabled = true;
     private boolean spectatorsEnabled = false;
     private boolean initialBoat = true;
+    private boolean replaceGhastDrop = false;
 
     public boolean starterInvulnerability() { return this.starterInvulnerability; }
     public int invulnerabilityDuration() { return this.invulnerabilityDuration; }
@@ -19,6 +20,8 @@ public class Game {
     public boolean papermanEnabled() { return this.papermanEnabled; }
     public boolean spectatorsEnabled() { return this.spectatorsEnabled; }
     public boolean initialBoat() { return this.initialBoat; }
+
+    public boolean replaceGhastDrop() { return this.replaceGhastDrop; }
 
     private PlayerList playerList = new PlayerList();
 

--- a/plugin/src/main/java/io/github/wickeddroid/plugin/listener/vanilla/EntityDamageListener.java
+++ b/plugin/src/main/java/io/github/wickeddroid/plugin/listener/vanilla/EntityDamageListener.java
@@ -59,6 +59,8 @@ public class EntityDamageListener implements Listener {
 
       if(!game.ironmanEnabled()) { return; }
 
+      if(uhcGame.getIronmans().size() == 1) { return; }
+
       uhcGame.removeIronman(player.getName());
       lostIronmans++;
 

--- a/plugin/src/main/java/io/github/wickeddroid/plugin/listener/vanilla/EntityDeathEvent.java
+++ b/plugin/src/main/java/io/github/wickeddroid/plugin/listener/vanilla/EntityDeathEvent.java
@@ -1,0 +1,27 @@
+package io.github.wickeddroid.plugin.listener.vanilla;
+
+import io.github.wickeddroid.plugin.game.Game;
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+import team.unnamed.inject.Inject;
+
+import java.util.ArrayList;
+
+public class EntityDeathEvent implements Listener {
+
+    @Inject
+    private Game game;
+
+    @EventHandler
+    public void onEntityDeath(org.bukkit.event.entity.EntityDeathEvent event) {
+        if(!game.replaceGhastDrop()) { return; }
+        if(event.getEntityType() != EntityType.GHAST) { return; }
+        if(event.getDrops().isEmpty()) { return; }
+
+        event.getDrops().clear();
+        event.getDrops().add(new ItemStack(Material.GOLD_INGOT));
+    }
+}

--- a/plugin/src/main/java/io/github/wickeddroid/plugin/loader/ListenerLoader.java
+++ b/plugin/src/main/java/io/github/wickeddroid/plugin/loader/ListenerLoader.java
@@ -27,6 +27,7 @@ public class ListenerLoader implements Loader {
   private FoodLevelChangeListener foodLevelChangeListener;
   private EntityDamageListener entityDamageListener;
   private PlayerAdvancementCriterionGrantListener playerAdvancementCriterionGrantListener;
+  private EntityDeathEvent entityDeathEvent;
 
   @Override
   public void load() {
@@ -43,7 +44,8 @@ public class ListenerLoader implements Loader {
             playerPortalListener,
             foodLevelChangeListener,
             entityDamageListener,
-            playerAdvancementCriterionGrantListener
+            playerAdvancementCriterionGrantListener,
+            entityDeathEvent
     );
   }
 

--- a/plugin/src/main/java/io/github/wickeddroid/plugin/world/SafeScatter.java
+++ b/plugin/src/main/java/io/github/wickeddroid/plugin/world/SafeScatter.java
@@ -1,0 +1,69 @@
+package io.github.wickeddroid.plugin.world;
+
+
+import ca.spottedleaf.concurrentutil.executor.standard.PrioritisedExecutor;
+import io.github.wickeddroid.plugin.util.PluginUtil;
+import io.papermc.paper.chunk.system.ChunkSystem;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.chunk.ChunkStatus;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SafeScatter {
+
+
+    public static @NotNull CompletableFuture<List<Location>> scatterTask(String worldName, int maxX, int maxZ, int count) throws Exception {
+        final var world = Bukkit.getWorld(worldName);
+        List<Location> locations = new ArrayList<>();
+
+        var craftWorldClass = getCraftBukkit("CraftWorld");
+
+        var craftWorld = craftWorldClass.cast(world);
+        var handleField = craftWorld.getClass().getDeclaredField("world");
+        handleField.setAccessible(true);
+        var serverLevel = handleField.get(craftWorld);
+
+        CompletableFuture<List<Location>> completableFuture = new CompletableFuture<>();
+
+
+        for(int i = 0; locations.size() < count; i++) {
+            final var x = ThreadLocalRandom.current().nextInt(-maxX, maxX);
+            final var z = ThreadLocalRandom.current().nextInt(-maxZ, maxX);
+
+            final var y = world.getHighestBlockYAt(x, z);
+
+            var chunkX = x >> 4;
+            var chunkZ = z >> 4;
+
+            ChunkSystem.scheduleChunkLoad((ServerLevel) serverLevel, chunkX, chunkZ, false, ChunkStatus.FULL, true, PrioritisedExecutor.Priority.HIGHEST, chunkAccess -> {
+                var loc = new Location(world, x, y, z);
+
+                if(loc.getWorld().getBlockAt(loc).isLiquid()) { return; }
+
+                locations.add(loc);
+            });
+
+
+            if(locations.size() >= count) {
+                completableFuture.complete(locations);
+            }
+        }
+
+        return completableFuture;
+    }
+
+
+    public static final String CRAFTBUKKIT = "org.bukkit.craftbukkit";
+    public static final String VERSION = Bukkit.getServer().getClass().getPackage().getName().substring(CRAFTBUKKIT.length() + 1);
+    protected static Class<?> getCraftBukkit(String name) throws ClassNotFoundException {
+        return Class.forName(CRAFTBUKKIT + "." + VERSION + "." + name);
+    }
+}


### PR DESCRIPTION
# ¡Patch Notes!

## Cambios:

*  Se agregó la configuración `replace-ghast-drop`. Su valor es falso por defecto y desactiva el drop de los ghast reemplazandolo por un lingote de oro.
*  Cuando el Ironman pierde vida por primera vez ya no se anuncia.
*  Se agregó la configuración `use-experimental-scatter`. Su valor es falso por defecto y activa el Scatter Experimental.
* A partir de ahora el scatter primero genera las coordenadas necesarias y luego teletransporta a partir de ellas.

## Experimental Safe Scatter:

### Consiste en un sistema el cual el TP de los jugadores se realiza en un proceso secuencial:

1- Se solicita X cantidad de localizaciones a hacer TP.
2- Se genera una coordenada.
3- Se carga ese chunk.
4- Verifica si esa coordenada es un líquido, de ser así se cancela y vuelve al paso 2.
5- Agrega la coordenada a la lista.
6- Una vez terminada la lista devuelve todas las coordenadas y se utilizan para teletransportar a los jugadores

* Este sistema utiliza el motor de chunks interno del juego, por ende posee mayor velocidad.

## Fixes:
* El comando `/uhc-staff time set` ahora funciona correctamente y sirve tanto para agregar como quitar tiempo de la partida.
* Cuando el Ironman pierde vida por primera vez ya no se anuncia.